### PR TITLE
Fix showcase grid container overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -100,7 +100,7 @@ pre {
 
 .showcase .grid {
   overflow: visible;
-  grid-template-columns: 55% 45%;
+  grid-template-columns: 55% auto;
   gap: 30px;
 }
 


### PR DESCRIPTION
The grid overflow the container. That happens because the gap is added to grid template. It happens something like this 55% + 45% + 30px