### PR TITLE
Added hover effect of social icons under footer section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -262,6 +262,22 @@ pre {
   margin: 0 10px;
 }
 
+.fa-github:hover {
+  color: #000000;
+}
+
+.fa-facebook:hover {
+  color: #1773EA;
+}
+
+.fa-instagram:hover {
+  color: #B32E87;
+}
+
+.fa-twitter:hover {
+  color: #1C9CEA;
+}
+
 /* Animations */
 @keyframes slideInFromLeft {
   0% {


### PR DESCRIPTION
Added hover effect to **GitHub, Facebook, Instagram & Twitter** icons under footer section.

- Before :

![Before](https://user-images.githubusercontent.com/87753750/128383420-7efe7ed0-28cf-464f-b7e6-a4700bf952ca.gif)

- After :

![After](https://user-images.githubusercontent.com/87753750/128383459-d7ee6b27-c70e-4ab6-bbe2-33a1febf3ed7.gif)

